### PR TITLE
Don't try to close the socket if it is undefined

### DIFF
--- a/src/statman_graphite_pusher.erl
+++ b/src/statman_graphite_pusher.erl
@@ -81,7 +81,10 @@ handle_info({timeout, Timer, {push, Interval}}, #state{timer = Timer} = State) -
             error_logger:warning_msg(
               "statman_graphite: failed to push to graphite: ~p",
               [Reason]),
-            ok = gen_tcp:close(State#state.socket),
+            case State#state.socket of
+                undefined -> ok;
+                Socket -> ok = gen_tcp:close(Socket)
+            end,
             {noreply, State#state{timer = NewTimer}}
     end;
 


### PR DESCRIPTION
It's time to say farewell to our favourite error message:

    13:00:59.283 [error] GenServer :statman_graphite_pusher terminating
    ** (FunctionClauseError) no function clause matching in :inet.tcp_close/1
        (kernel) inet.erl:1642: :inet.tcp_close(:undefined)
        (statman_graphite) statman_graphite_pusher.erl:84: :statman_graphite_pusher.handle_info/2
        (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
        (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
    Last message: {:timeout, #Reference<0.915812543.3718512642.116948>, {:push, 60000}}
    State: {:state, #Reference<0.915812543.3718512642.116948>, "dev", {'graphite-host', 2003}, :undefined, #Function<0.63501349/1 in :statman_graphite_pusher.init/1>}

We'll have to make do with this one from now on:

    13:00:59.281 [warn]  statman_graphite: failed to push to graphite: :nxdomain